### PR TITLE
Replace OffsetDateTime call by Date.

### DIFF
--- a/android/src/main/kotlin/co/sunnyapp/flutter_contact/Contact.kt
+++ b/android/src/main/kotlin/co/sunnyapp/flutter_contact/Contact.kt
@@ -7,7 +7,8 @@ import android.net.Uri
 import android.os.Build
 import android.provider.ContactsContract
 import androidx.annotation.RequiresApi
-import java.time.OffsetDateTime
+import java.time.Instant
+import java.util.Date
 
 typealias StructList = List<Struct>
 typealias Struct = Map<String, Any>
@@ -30,7 +31,7 @@ data class Contact(
         var suffix: String? = null,
         var company: String? = null,
         var jobTitle: String? = null,
-        var lastModified: OffsetDateTime? = null,
+        var lastModified: Date ? = null,
         var note: String? = null,
         val emails: MutableList<Item> = mutableListOf(),
         val groups: MutableSet<String> = linkedSetOf(),
@@ -68,7 +69,6 @@ data class Contact(
 
   companion object {
 
-    @RequiresApi(Build.VERSION_CODES.O)
     fun fromMap(map: Map<String, *>): Contact {
       val contact = Contact(
           identifier = (map["identifier"] as String?)?.let{ContactId(it)},
@@ -96,8 +96,7 @@ data class Contact(
   }
 }
 
-@RequiresApi(Build.VERSION_CODES.O)
-fun String.toDate(): OffsetDateTime = OffsetDateTime.parse(this)
+fun String.toDate(): Date = Date.from(Instant.parse(this))
 fun MutableList<ContactDate>.toContactDateMap() = map { it.toMap() }
 fun MutableList<Item>.toItemMap() = map { it.toMap() }
 fun MutableList<PostalAddress>.toAddressMap() = map { it.toMap() }

--- a/android/src/main/kotlin/co/sunnyapp/flutter_contact/resolver-extensions.kt
+++ b/android/src/main/kotlin/co/sunnyapp/flutter_contact/resolver-extensions.kt
@@ -10,7 +10,8 @@ import android.provider.ContactsContract
 import androidx.annotation.RequiresApi
 import io.flutter.plugin.common.MethodChannel
 import java.io.ByteArrayOutputStream
-import java.time.OffsetDateTime
+import java.time.Instant
+import java.util.Date
 
 @SuppressLint("Recycle")
 fun ContentResolver.queryContacts(query: String? = null, sortBy: String? = null,
@@ -101,7 +102,7 @@ fun Cursor?.toContactList(limit: Int, offset: Int): List<Contact> {
 
       ContactsContract.Data.CONTACT_LAST_UPDATED_TIMESTAMP -> {
         cursor.string(ContactsContract.Data.CONTACT_LAST_UPDATED_TIMESTAMP)?.also {
-          contact.lastModified = OffsetDateTime.parse(it)
+          contact.lastModified = Date.from(Instant.parse(it))
         }
       }
 


### PR DESCRIPTION
OffsetDateTime is avalaible only for sdk version > 26. Using the plugin with older version of Android causes an application crash.

This modification allows us to use the plugin with older version of Android. It uses java.util.Date which is the old java way to manage date with java.time.Instant which is the tool in Java 8 to keep compatibility with older Java version.

Tested this code on Android 4.4 it does not crash anymore.
