### PR TITLE
Updated podspec file to specify Swift 4.2 as required by changes made

### DIFF
--- a/ios/flutter_contact.podspec
+++ b/ios/flutter_contact.podspec
@@ -5,6 +5,7 @@
 Pod::Spec.new do |s|
   s.name             = 'flutter_contact'
   s.version          = '0.0.1'
+  s.swift_version    = '4.2'
   s.summary          = 'A plugin for managing contacts across platforms.'
   s.description      = <<-DESC
 A new flutter plugin project.


### PR DESCRIPTION
ContactFormsHandler.swift and others were receiving the following error:

UIKit.UIActivityIndicatorView:6:12: note: 'init(style:)' was introduced in Swift 4.2
public init(style: UIActivityIndicatorViewStyle)

This pull request updates the flutter_contact.podspec file to specify Swift 4.2.

