### PR TITLE
Cursor to Contact mapping fix for jobTitle attribute

### DIFF
--- a/android/src/main/kotlin/co/sunnyapp/flutter_contact/resolver-extensions.kt
+++ b/android/src/main/kotlin/co/sunnyapp/flutter_contact/resolver-extensions.kt
@@ -173,7 +173,7 @@ interface ContactExtensions {
                 CommonDataKinds.Organization.CONTENT_ITEM_TYPE -> {
                     contact.company = contact.company
                             ?: cursor.string(CommonDataKinds.Organization.COMPANY)
-                    contact.jobTitle = contact.company
+                    contact.jobTitle = contact.jobTitle
                             ?: cursor.string(CommonDataKinds.Organization.TITLE)
                 }
                 else -> {


### PR DESCRIPTION
Contacts read from device had jobTitle attribute incorrectly filled with value of company attribute.