### PR TITLE
Fix Partial Display Name Query

### DIFF
--- a/android/src/main/kotlin/co/sunnyapp/flutter_contact/contact-from-cursor-ext.kt
+++ b/android/src/main/kotlin/co/sunnyapp/flutter_contact/contact-from-cursor-ext.kt
@@ -46,7 +46,7 @@ interface ContactExtensions {
 
         val projections = if (forCount) mode.projectionsIdsOnly else mode.projections
         if (query != null) {
-            selectionArgs = arrayOf("$query%")
+            selectionArgs = arrayOf("%$query%")
             selection = "${Data.DISPLAY_NAME_PRIMARY} LIKE ?"
         }
 


### PR DESCRIPTION
I believe that users should be able to search for a contact name, this includes middle names, last names, etc.