### PR TITLE
Fix Android arbitrary date string parsing

### DIFF
--- a/android/src/main/kotlin/co/sunnyapp/flutter_contact/ContactDate.kt
+++ b/android/src/main/kotlin/co/sunnyapp/flutter_contact/ContactDate.kt
@@ -52,28 +52,39 @@ fun Date?.toIsoString(): String? {
  * 2009-12-22
  *
  */
-fun DateComponents.Companion.tryParse(input: String) =
-        try {
-            fromDateTime(isoDateParser.parseDateTime(input.trim()))
-        } catch (e: Exception) {
-            val parts = input.split("-")
-                    .flatMap { it.split("/") }
-                    .filter { !it.isBlank() }
-                    .map { value -> value.trimStart('0') }
-                    .map { it.toInt() }
+fun DateComponents.Companion.tryParse(input: String): DateComponents? {
+    val fromDateTime = try {
+        fromDateTime(isoDateParser.parseDateTime(input.trim()))
+    } catch (e: Exception) {
+        null
+    }
 
-            val fromParts = when (parts.size) {
-                3 -> DateComponents(year = parts[0], month = parts[1], day = parts[2])
-                1 -> DateComponents(year = parts[0])
-                2 -> when {
-                    parts[0] > 1000 -> DateComponents(year = parts[0], month = parts[1])
-                    else -> DateComponents(month = parts[0], day = parts[1])
-                }
-                else -> null
+    if (fromDateTime != null) return fromDateTime
+
+    val fromParts = try {
+        val parts = input.split("-")
+                .flatMap { it.split("/") }
+                .filter { !it.isBlank() }
+                .map { it.trimStart('0') }
+                .map { it.toInt() }
+
+        when (parts.size) {
+            3 -> DateComponents(year = parts[0], month = parts[1], day = parts[2])
+            1 -> DateComponents(year = parts[0])
+            2 -> when {
+                parts[0] > 1000 -> DateComponents(year = parts[0], month = parts[1])
+                else -> DateComponents(month = parts[0], day = parts[1])
             }
-            fromParts
+            else -> null
         }
+    } catch (e: Exception) {
+        null
+    }
 
+    if (fromParts != null) return fromParts
+
+    return null
+}
 
 fun DateComponents.Companion.fromDateTime(date: DateTime): DateComponents {
     return DateComponents(month = date.monthOfYear, year = date.year, day = date.dayOfMonth)


### PR DESCRIPTION
Thanks for your great fork, I have been using it in production for a while and it works great, however, I hit an issue with one of my app's customers who is using an Android device because of a non-standard arbitrary birthday string in one of his contacts and I was able to reproduce the same issue using the `example` app.

I understand that the library has been migrated already to `flexidate` plugin for better date parsing, however, the issue is still reproducible, please check the _steps to reproduce_ below for more details.

**Steps to reproduce:**

1. Use an Android device with their contacts synced to Google Contacts
2. Opened one of the synced contacts via Google Contacts web UI (https://contacts.google.com/)
3. Edit the contact
4. Show more fields
5. Add a non-standard arbitrary birthday string (i.e. `7 July 1960`)
6. Wait for the contact to be synced back to the mobile device
7. Open the example app

**Expected:**
* Device contacts are loaded after sometime

**Actual:**
* The `example` app keeps loading indefinitely and the following `PlatformException` is thrown in the console:
```
[ERROR:flutter/lib/ui/ui_dart_state.cc(199)] Unhandled Exception: PlatformException(unknown, java.lang.NumberFormatException: For input string: "7 July 1960", java.lang.NumberFormatException: For input string: "7 July 1960", null)
#0      StandardMethodCodec.decodeEnvelope (package:flutter/src/services/message_codecs.dart:597:7)
#1      MethodChannel._invokeMethod (package:flutter/src/services/platform_channel.dart:158:18)
<asynchronous suspension>
#2      _defaultPageGenerator.<anonymous closure> (package:flutter_contact/base_contacts.dart:90:25)
<asynchronous suspension>
#3      _PeopleListPageState.refreshContacts (package:flutter_contact_example/people_list_page.dart:70:14)
<asynchronous suspension>
```