### PR TITLE
Android: adjust cursor position when skipping

### DIFF
--- a/android/src/main/kotlin/co/sunnyapp/flutter_contact/contact-from-cursor-ext.kt
+++ b/android/src/main/kotlin/co/sunnyapp/flutter_contact/contact-from-cursor-ext.kt
@@ -82,7 +82,7 @@ interface ContactExtensions {
             /// We overshoot because one record could involve multiple rows.
             if(skipped.size > offset) {
                 skipped.remove(skipped.last())
-                // move the cursor to previous position as the last record is skipped.
+                // move the cursor to previous position as we don't want to skip this contact row
                 cursor.moveToPrevious()
             }
         }

--- a/android/src/main/kotlin/co/sunnyapp/flutter_contact/contact-from-cursor-ext.kt
+++ b/android/src/main/kotlin/co/sunnyapp/flutter_contact/contact-from-cursor-ext.kt
@@ -82,6 +82,8 @@ interface ContactExtensions {
             /// We overshoot because one record could involve multiple rows.
             if(skipped.size > offset) {
                 skipped.remove(skipped.last())
+                // move the cursor to previous position as the last record is skipped.
+                cursor.moveToPrevious()
             }
         }
 


### PR DESCRIPTION
Resolves https://github.com/SunnyApp/flutter_contact/issues/65

When we fetch the next page of contacts, the cursor is skipping the previous page contacts. But the skipped contacts length can be greater than the limit because of the while loop condition:
https://github.com/deepak786/flutter_contact/blob/e58e03cc63281ff356f2f743d400bfe11ff227eb/android/src/main/kotlin/co/sunnyapp/flutter_contact/contact-from-cursor-ext.kt#L77

The array starts at `0` and we are comparing here `<=`. We can't use it here just `<` otherwise the same issue arises.

In this particular case (overshoot), we don't want to skip the last contact which is already being removed from the `skipped` list but the cursor position still remains the same. So we need to move the cursor to the previous position. If we don't move the cursor to the previous position then some data of the first contact will not be available in the result.