### PR TITLE
docs: dependency version update

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ To use this plugin, add `flutter_contact` as a [dependency in your `pubspec.yaml
 For example:  
 ```yaml  
 dependencies:  
-    flutter_contact: ^0.6.1
+    flutter_contact: ^0.9.1+7
 ```
   
 ## Permissions  
 ### Android  
-Add the following permissions to your AndroidManifest.xml:  
+Add the following permissions to your `AndroidManifest.xml`:  
   
 ```xml  
 <uses-permission android:name="android.permission.READ_CONTACTS" />  


### PR DESCRIPTION
Thank you for the compatible package.
On the setup part of the package on the main documentation page, I noticed the dependency version was no the updated one which I thought might be confusing for some of the new package users.
This PR is created after the dependency version update on the documentation page :)